### PR TITLE
Support ssys in catalogs and simplify schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+## [1.1.1](https://github.com/stac-extensions/ssys/releases/tag/v1.1.1) - 2026-02-06
+### Added
+- Fix examples
+- Support ssys for catalogsy
+
 ## [1.1.0](https://github.com/stac-extensions/ssys/releases/tag/v1.1.0) - 2023-10-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Solar System Extension Specification
 
 - **Title:** Solar System
-- **Identifier:** <https://stac-extensions.github.io/ssys/v1.1.0/schema.json>
+- **Identifier:** <https://stac-extensions.github.io/ssys/v1.1.1/schema.json>
 - **Field Name Prefix:** ssys
 - **Scope:** Item, Catalog, Collection
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/README.md#extension-maturity):** Proposal
 - **Owner**: @jlaura
 
-This document explains the fields of the STAC Solar System (SSYS) Extension to a STAC Item, Catalog, or Collection. 
-SSYS covers data sets that represents an individual image, mosaic, or derived raster of a planetary body. Examples 
-of SSYS data include sensors with visible, short-wave and mid-wave IR bands (e.g., the THEMIS instrument on Mars 
-Odyssey), visible images (e.g. Context Camera (CTX) aboard Mars Global Surveyor), or derived data sets like digital 
-elevation models (DEM/DTM).
+This document explains the fields of the STAC Solar System (SSYS) Extension to a STAC Item, Catalog, or Collection.
+SSYS covers data sets that represents an individual image, mosaic, or derived raster of a planetary 
+body.
+Examples of SSYS data include sensors with visible, short-wave and mid-wave IR bands (e.g., the 
+THEMIS instrument on Mars Odyssey), visible images (e.g. Context Camera (CTX) aboard Mars Global 
+Surveyor), or derived data sets like digital elevation models (DEM/DTM).
 
 - Examples:
 - [Catalog Example (Europa Galileo SSI Image)](examples/catalog.json)
@@ -31,32 +32,35 @@ elevation models (DEM/DTM).
 
 #### ssys:targets
 
-the field `ssys:targets` allows to have one or more targets listed within an array of strings. This can 
-happen, for example, if several moons are in the same view. As an example, this scene has both of Ganymede
-and Jupiter in the same image as taken by the NASA mission Cassini [PIA02862](https://photojournal.jpl.nasa.gov/catalog/PIA02862).
+the field `ssys:targets` allows to have one or more targets listed within an array of strings. 
+This can happen, for example, if several moons are in the same view. As an example, this scene 
+has both of Ganymede and Jupiter in the same image as taken by the NASA mission Cassini 
+[PIA02862](https://photojournal.jpl.nasa.gov/catalog/PIA02862).
 
 #### ssys:local_time
 
-the field `ssys:local_time` allows for API searchable non-UTC time definitions. The time should be encoded in a 
-string that is lexicographically sortable. It is unlikley that this time should be something like the SpacecraftClockCount or another 
-entry from the PDS metadata as most metadata files do not include a local (or local solar time). This field exists to support discovery
-in a time format that is meaningful to the user. Suggested formats are provided below:
+the field `ssys:local_time` allows for API searchable non-UTC time definitions. The time should be 
+encoded in a string that is lexicographically sortable. It is unlikley that this time should be 
+something like the SpacecraftClockCount or another entry from the PDS metadata as most metadata 
+files do not include a local (or local solar time). This field exists to support discovery in a 
+time format that is meaningful to the user. Suggested formats are provided below:
 
-| Body | Time String Format |
-| -----| -------------------|
+| Body | Time String Format       |
+| -----| -------------------------|
 | Mars | `MarsYear:Sol:LocalTime` |
 
-As a fallback one can consider using the Julian date. This has drawbacks though, as the Julian date does not 
-account for the day/night cycle in different bodies which is often a factor in selecting data.
+As a fallback one can consider using the Julian date. This has drawbacks though, as the Julian date
+does not account for the day/night cycle in different bodies which is often a factor in selecting data.
 
 #### ssys:target_class
 
 the field `ssys:target_class` identifies the type of the target. Solar System bodies are defined without ambiguity by the couple
 target_class and target_name. Values for this class are derived from the 
-[International Virtual Observatory Alliance](https://www.ivoa.net/documents/EPNTAP/20220822/REC-EPNTAP-2.0.html#tth_sEc2.1.3) 
+[International Virtual Observatory Alliance](https://www.ivoa.net/documents/EPNTAP/20220822/REC-EPNTAP-2.0.html#tth_sEc2.1.3)
 target description parameter.
 
-Accepted values are: 
+Accepted values are:
+
 - asteroid
 - dwarf_planet
 - planet
@@ -81,16 +85,18 @@ for running tests are copied here for convenience.
 
 ### Running tests
 
-The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid. 
+The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid.
 To run tests locally, you'll need `npm`, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
 
 First you'll need to install everything with npm once. Just navigate to the root of this repository and on 
 your command line run:
+
 ```bash
 npm install
 ```
 
 Then to check markdown formatting and test the examples against the JSON schema, you can run:
+
 ```bash
 npm test
 ```
@@ -98,6 +104,7 @@ npm test
 This will spit out the same texts that you see online, and you can then go and fix your markdown or examples.
 
 If the tests reveal formatting problems with the examples, you can fix them with:
+
 ```bash
 npm run format-examples
 ```

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -1,7 +1,10 @@
 {
   "id": "usgs_europa_catalog",
   "type": "Catalog",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/ssys/v1.1.1/schema.json"
+  ],
   "description": "USGS provided analysis ready data for Europa. All collections within this catalog are GIS ready and served as cloud optimized Geotiffs. To visualize these data in ArcGIS Pro please [see this guide](https://opengislab.com/blog/2021/4/25/accessing-cloud-optimized-geotiffs-in-arcgis-pro), to access these data in QGIS please [see this guide](https://www.cogeo.org/qgis-tutorial.html).\n",
   "ssys:targets": [
     "Europa"

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,7 +1,10 @@
 {
   "id": "usgs_controlled_images_voy1_voy2_galileo",
   "type": "Collection",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/ssys/v1.1.1/schema.json"
+  ],
   "ssys:targets": [
     "Europa"
   ],

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,10 +1,8 @@
 {
   "type": "Feature",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/datacube/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/ssys/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/ssys/v1.1.1/schema.json"
   ],
   "id": "item",
   "properties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,90 +1,26 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://stac-extensions.github.io/ssys/v1.1.0/schema.json",
+	"$id": "https://stac-extensions.github.io/ssys/v1.1.1/schema.json",
 	"title": "SSYS Extension",
-	"description": "STAC Solar System Extension for STAC Items, Catalogs, or Collections.",
+	"description": "STAC Solar System Extension for STAC Items, Catalogs, and Collections.",
 	"oneOf": [
 		{
-			"$comment": "This is the schema for STAC Items.",
-			"allOf": [
-				{
-					"$ref": "#/definitions/stac_extensions"
-				},
-				{
-					"type": "object",
-					"required": [
-						"type",
-						"properties",
-						"assets"
-					],
-					"properties": {
-						"type": {
-							"const": "Feature"
-						},
-						"properties": {
-							"$ref": "#/definitions/fields"
-						},
-						"assets": {
-							"type": "object",
-							"additionalProperties": {
-								"$ref": "#/definitions/fields"
-							}
-						}
-					}
-				}
-			]
+			"$ref": "#/definitions/item"
 		},
 		{
-			"$comment": "This is the schema for STAC Collections.",
-			"allOf": [
-				{
-					"type": "object",
-					"required": [
-						"type"
-					],
-					"properties": {
-						"type": {
-							"const": "Collection"
-						},
-						"assets": {
-							"type": "object",
-							"additionalProperties": {
-								"$ref": "#/definitions/fields"
-							}
-						},
-						"item_assets": {
-							"type": "object",
-							"additionalProperties": {
-								"$ref": "#/definitions/fields"
-							}
-						}
-					}
-				},
-				{
-					"$ref": "#/definitions/stac_extensions"
-				}
-			]
+			"$ref": "#/definitions/collection"
+		},
+		{
+			"$ref": "#/definitions/catalog"
 		}
 	],
 	"definitions": {
-		"stac_extensions": {
-			"type": "object",
-			"required": [
-				"stac_extensions"
-			],
-			"properties": {
-				"stac_extensions": {
-					"type": "array",
-					"contains": {
-						"const": "https://stac-extensions.github.io/ssys/v1.1.0/schema.json"
-					}
-				}
-			}
-		},
 		"fields": {
 			"type": "object",
+			"description": "SSYS extension fields.",
 			"properties": {
 				"ssys:targets": {
+					"description": "List of solar system targets relevant to the data.",
 					"type": "array",
 					"minItems": 1,
 					"items": {
@@ -92,31 +28,96 @@
 					}
 				},
 				"ssys:local_time": {
-					"title": "Local time",
+					"title": "Local Time",
+					"description": "Local solar time at the observation target.",
 					"type": "string"
 				},
 				"ssys:target_class": {
-					"title": "target_class",
+					"title": "Target Class",
+					"description": "Classification of the observed target.",
 					"type": "string",
-					"enum": ["asteroid", 
-					         "dwarf_planet", 
-							 "planet", 
-							 "satellite", 
-							 "comet", 
-							 "exoplanet", 
-							 "interplanetary_medium", 
-							 "sample", 
-							 "sky", 
-							 "spacecraft", 
-							 "spacejunk", 
-							 "star", 
-							 "calibration"]
+					"enum": [
+						"asteroid",
+						"dwarf_planet",
+						"planet",
+						"satellite",
+						"comet",
+						"exoplanet",
+						"interplanetary_medium",
+						"sample",
+						"sky",
+						"spacecraft",
+						"spacejunk",
+						"star",
+						"calibration"
+					]
 				}
 			},
 			"patternProperties": {
 				"^(?!ssys:)": {}
 			},
 			"additionalProperties": false
+		},
+		"asset_fields": {
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/definitions/fields"
+			}
+		},
+		"item": {
+			"$comment": "Schema for STAC Items.",
+			"type": "object",
+			"required": [
+				"type",
+				"properties",
+				"assets"
+			],
+			"properties": {
+				"type": {
+					"const": "Feature"
+				},
+				"properties": {
+					"$ref": "#/definitions/fields"
+				},
+				"assets": {
+					"$ref": "#/definitions/asset_fields"
+				}
+			}
+		},
+		"collection": {
+			"$comment": "Schema for STAC Collections.",
+			"type": "object",
+			"required": [
+				"type"
+			],
+			"properties": {
+				"type": {
+					"const": "Collection"
+				},
+				"assets": {
+					"$ref": "#/definitions/asset_fields"
+				},
+				"item_assets": {
+					"$ref": "#/definitions/asset_fields"
+				}
+			}
+		},
+		"catalog": {
+			"$comment": "Schema for STAC Catalogs.",
+			"type": "object",
+			"required": [
+				"type"
+			],
+			"properties": {
+				"type": {
+					"const": "Catalog"
+				}
+			},
+			"allOf": [ 
+				{ 
+					"$ref": "#/definitions/fields" 
+				} 
+			]
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/ssys/v1.1.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/ssys/v1.1.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/ssys/v1.1.1/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/ssys/v1.1.1/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^8.0.0",


### PR DESCRIPTION
fix(schema): support ssys in catalogs and simplify schema validation

- Remove add_extension checks (schema is only invoked when an extension is defined)
- Add extensions to examples
- Upgrade version to 1.1.1

